### PR TITLE
Upgrade AWS SDK to v3

### DIFF
--- a/guidepost.gemspec
+++ b/guidepost.gemspec
@@ -11,5 +11,5 @@ Gem::Specification.new do |s|
     s.required_ruby_version = '>= 2.5.0'
     s.licenses              = ["MIT"]
 
-    s.add_dependency("aws-sdk", "~> 2.0")
+    s.add_dependency("aws-sdk-s3", "~> 1")
 end

--- a/lib/guidepost.rb
+++ b/lib/guidepost.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-s3'
 require 'cgi'
 require 'json'
 require 'net/http'


### PR DESCRIPTION
Hey Kiren! 👋 🙂 

I made this quick PR to support the [v3 of the AWS SDK](https://aws.amazon.com/blogs/developer/deprecation-schedule-for-aws-sdk-for-ruby-v2/), as the v2 is deprecated and will be discontinued in November 2020

Hope that works for you :)

Cheers!